### PR TITLE
Fix rendering of the definition content

### DIFF
--- a/sphinxcontrib/autoyaml/__init__.py
+++ b/sphinxcontrib/autoyaml/__init__.py
@@ -89,11 +89,13 @@ class AutoYAMLDirective(Directive):
                 comment = comments.get(end_line + 1)
                 if comment:
                     with switch_source_input(self.state, comment):
-                        node = nodes.paragraph(text=token.value)
                         definition = nodes.definition()
-                        node += definition
                         self.state.nested_parse(comment, 0, definition)
-                        yield node
+                        item = nodes.definition_list_item('',
+                                nodes.term('', token.value),
+                                definition)
+                        dlist = nodes.definition_list('', item)
+                        yield dlist
 
 
 def setup(app):

--- a/sphinxcontrib/autoyaml/__init__.py
+++ b/sphinxcontrib/autoyaml/__init__.py
@@ -96,9 +96,10 @@ class AutoYAMLDirective(Directive):
                         extra_line = nodes.line('', '')
                         definition += extra_line
                         self.state.nested_parse(comment, 0, definition)
-                        item = nodes.definition_list_item('',
-                                nodes.term('', token.value),
-                                definition)
+                        item = nodes.definition_list_item(
+                            '',
+                            nodes.term('', token.value),
+                            definition)
                         dlist = nodes.definition_list('', item)
                         yield dlist
 

--- a/sphinxcontrib/autoyaml/__init__.py
+++ b/sphinxcontrib/autoyaml/__init__.py
@@ -90,6 +90,11 @@ class AutoYAMLDirective(Directive):
                 if comment:
                     with switch_source_input(self.state, comment):
                         definition = nodes.definition()
+                        # Insert an extra line for backwards-compat with
+                        # the text format that requires an empty line after
+                        # the node name
+                        extra_line = nodes.line('', '')
+                        definition += extra_line
                         self.state.nested_parse(comment, 0, definition)
                         item = nodes.definition_list_item('',
                                 nodes.term('', token.value),

--- a/tests/examples/output/index.txt
+++ b/tests/examples/output/index.txt
@@ -2,24 +2,20 @@ Hello world!
 ************
 
 something1
-
    Value description
 
       - property1: "value1"
         property2: "value2"
 
 something2
-
    Continue sentence to next line
 
    Forced newline.
 
 nested_key
-
    Nested key
 
 something6
-
    No trailing space
 
    in this comment.

--- a/tests/examples/output/index.txt
+++ b/tests/examples/output/index.txt
@@ -2,20 +2,24 @@ Hello world!
 ************
 
 something1
+
    Value description
 
       - property1: "value1"
         property2: "value2"
 
 something2
+
    Continue sentence to next line
 
    Forced newline.
 
 nested_key
+
    Nested key
 
 something6
+
    No trailing space
 
    in this comment.


### PR DESCRIPTION
As of 28c94ee0b925e the HTML output for a yaml file was roughly this:
```html
    <p>yaml-node-name <dd><p>extracted comments</p></dd> </p>
```

A ``<dd>`` outside a ``<dl>`` isn't rendered correctly, so the output was just a list of paragraphs with identical formatting.

Fix this by making sure our content is within a definition list, resulting in the following HTML output:

```html
    <dl><dt>yaml-node-name</dt><dd><p>extracted comments</p></dd></dl>
```

Note how this is a "freestanding" ``<dl>`` now, there is no wrapping ``<p>`` but that could be added if backwards-compatibility requires it.

**Note:** first patch fixes the HTML rendering but the text rendering changes (see the hunks in `tests/examples/output/index.txt`). The newline after the YAML node name is missing - the second patch fixes that by forcing a newline at the beginning of the definition. Depending on whether you want that or not I can drop that patch or you can squash the two together.