### PR TITLE
Use '>=' for ruamel.yaml to support latest version

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+# [1.1.2] - 2024-11-13
+### Changed
+- Support for ruamel.yaml 18.x
+
 # [1.1.1] - 2023-04-12
 ### Fixed
 - Comment strings from multiline scalar values aren't mistakenly used anymore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = '^3.6'
 Sphinx = '>=3.5.1'
-'ruamel.yaml' = '^0.16.12'
+'ruamel.yaml' = '>=0.16.12'
 
 [tool.poetry.dev-dependencies]
 sphinx-testing = "^1.0.1"


### PR DESCRIPTION
Hello, I am one of the users of this repository, and I encountered a version issue during pip install. Currently, ruamel has been updated to 0.18.x.

Although many APIs from tuamel have changed since 0.17, I have checked the usage here, and it is available in all of 0.16, 0.17, and 0.18, so I updated the version constraints.

Could you please take a look?
